### PR TITLE
Potential bug fix for not rendering a layout view when a partial view was present

### DIFF
--- a/Westwind.RazorHosting/HostContainers/RazorFolderHostContainer.cs
+++ b/Westwind.RazorHosting/HostContainers/RazorFolderHostContainer.cs
@@ -114,6 +114,7 @@ namespace Westwind.RazorHosting
             }
 
             // Set configuration data that is to be passed to the template (any object) 
+            var previousConfiguration = Engine.TemplatePerRequestConfigurationData;
             Engine.TemplatePerRequestConfigurationData = new RazorFolderHostTemplateConfiguration()
             {
                 TemplatePath = Path.Combine(TemplatePath, relativePath),
@@ -160,8 +161,9 @@ namespace Westwind.RazorHosting
             {                
                 writer?.Close();
 
-                // Clear out the per request cache
-                Engine.TemplatePerRequestConfigurationData = null;
+                // Restore the previous per request cache
+                // This will be null after all views in this request are processed
+                Engine.TemplatePerRequestConfigurationData = previousConfiguration;
             }
 
             return result;


### PR DESCRIPTION
Potential fix:

Cache Engine.TemplatePerRequestConfigurationData at the beginning of rendering a template, and restore it when finished. Previously, Engine.TemplatePerRequestConfigurationData was being cleared after every view was rendered, which would clear it out after partial views, leaving layouts to be abandoned.

At the beginning of a request chain, it appears that Engine.TemplatePerRequestConfigurationData is null, and it is restored to null at the end.

All FolderHostTests continue to pass after this change.